### PR TITLE
Patch to add --tests=<regexp>,<regexp>

### DIFF
--- a/src/main/java/com/novocode/junit/JUnitFilter.java
+++ b/src/main/java/com/novocode/junit/JUnitFilter.java
@@ -9,8 +9,10 @@ public final class JUnitFilter extends Filter {
   private static final String DELIMITER = "\\,";
 
   private String[] testPatterns;
+  private EventDispatcher ed_;
 
-  public JUnitFilter(String testFilter) {
+  public JUnitFilter(String testFilter, EventDispatcher ed) {
+    ed_ = ed;
     if (testFilter != null) {
       testPatterns = testFilter.split(DELIMITER);
     }
@@ -39,6 +41,10 @@ public final class JUnitFilter extends Filter {
 
     // If we have no test patterns, run everything
     // If we have any, and made it down here, return false
-    return testPatterns == null || testPatterns.length == 0;
+    boolean shouldRun = testPatterns == null || testPatterns.length == 0;
+    if (!shouldRun) {
+      ed_.testIgnored(d);
+    }
+    return shouldRun;
   }
 }

--- a/src/main/java/com/novocode/junit/JUnitRunner.java
+++ b/src/main/java/com/novocode/junit/JUnitRunner.java
@@ -50,7 +50,7 @@ final class JUnitRunner extends Runner2
     try
     {
       Class<?> cl = testClassLoader.loadClass(testClassName);
-      Request request = Request.classes(cl).filterWith(new JUnitFilter(testFilter));
+      Request request = Request.classes(cl).filterWith(new JUnitFilter(testFilter, ed));
       try { ju.run(request); } finally { ed.uncapture(true); }
     }
     catch(Exception ex) { ed.post(new TestExecutionFailedEvent(testClassName, ex)); }


### PR DESCRIPTION
Hi Stefan--

I'm an engineer @ 4sq and for a long time I've wanted the ability to run specific testcases within a class. This patch add a bunch of options (you should pick which flag name you like best) to define one or more regexps that filter down which testcases should be run.

Thanks,
--dave
