### PR TITLE
Failed assumptions should be skipped, not failed

### DIFF
--- a/src/main/java/com/novocode/junit/TestAssumptionFailedEvent.java
+++ b/src/main/java/com/novocode/junit/TestAssumptionFailedEvent.java
@@ -10,13 +10,13 @@ final class TestAssumptionFailedEvent extends AbstractEvent
 
   TestAssumptionFailedEvent(Failure failure)
   {
-    super(buildName(failure.getDescription()), failure.getMessage(), Result.Failure, failure.getException());
+    super(buildName(failure.getDescription()), failure.getMessage(), Result.Skipped, failure.getException());
     this.failure = failure;
   }
 
   @Override
   public void logTo(RichLogger logger)
   {
-    logger.error("Test assumption in test "+AbstractEvent.buildName(failure.getDescription())+" failed: "+failure.getMessage(), error);
+    logger.warn("Test assumption in test "+AbstractEvent.buildName(failure.getDescription())+" failed: "+failure.getMessage());
   }
 }


### PR DESCRIPTION
I changed failed assumptions to be reported as skipped, not failed. The purpose of assumptions is to determine wether a test can run or not given the provided assumptions. If an assumption fails the test should simply not be run.

More details can be found in the release notes from 4.4 http://junit.sourceforge.net/doc/ReleaseNotes4.4.html
