### PR TITLE
support JUnit3 test cases

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -3,6 +3,6 @@
 project.organization=com.novocode
 project.name=junit-interface
 sbt.version=0.7.4
-project.version=0.6
+project.version=0.6-patched
 build.scala.versions=2.7.7
 project.initialize=false

--- a/src/main/java/com/novocode/junit/JUnit3Fingerprint.java
+++ b/src/main/java/com/novocode/junit/JUnit3Fingerprint.java
@@ -1,0 +1,13 @@
+package com.novocode.junit;
+
+import org.scalatools.testing.SubclassFingerprint;
+
+
+public class JUnit3Fingerprint implements SubclassFingerprint
+{
+  @Override
+  public String superClassName() { return "junit.framework.TestCase"; }
+
+  @Override
+  public boolean isModule() { return false; }
+}

--- a/src/main/java/com/novocode/junit/JUnitFramework.java
+++ b/src/main/java/com/novocode/junit/JUnitFramework.java
@@ -8,7 +8,8 @@ import org.scalatools.testing.Runner;
 
 public final class JUnitFramework implements Framework
 {
-  private static final Fingerprint[] FINGERPRINTS = new Fingerprint[] { new JUnitFingerprint() };
+  private static final Fingerprint[] FINGERPRINTS =
+          new Fingerprint[] { new JUnitFingerprint(), new JUnit3Fingerprint() };
 
   @Override
   public String name() { return "JUnit"; }


### PR DESCRIPTION
hi, these changes add support for old-school JUnit3 test cases.
atm, i'm using it in a mixed java/scala sbt project. the java code was migrated from an existing maven project containing a mix of JUnit3 and JUnit4 test cases.
