### PR TITLE
Show causing exceptions even if we elided some JUnit frames

### DIFF
--- a/src/main/java/com/novocode/junit/RichLogger.java
+++ b/src/main/java/com/novocode/junit/RichLogger.java
@@ -49,10 +49,14 @@ final class RichLogger
     for(int i=0; i<=m; i++) error("    at " + trace[i]);
     if(m0 != m)
     {
+      // skip junit-related frames
       error("    ...");
-      return;
     }
-    if(framesInCommon != 0) error("    ... " + framesInCommon + " more");
+    else if(framesInCommon != 0)
+    {
+      // skip frames that were in the previous trace too
+      error("    ... " + framesInCommon + " more");
+    }
     logStackTraceAsCause(trace, t.getCause());
   }
 


### PR DESCRIPTION
Otherwise, you can get a mystery exception and not be able
to see its root cause. Previously the code would never look
at causes once it saw some JUnit stack frames.
