### PR TITLE
Junit-Dep as a dependency instead of Junit - to be able to separately add hamcrest dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.9-SNAPSHOT"
 
 crossPaths := false
 
-libraryDependencies += "junit" % "junit" % "4.8.2"
+libraryDependencies += "junit" % "junit-dep" % "4.8.2"
 
 libraryDependencies += "org.scala-tools.testing" % "test-interface" % "0.5"
 


### PR DESCRIPTION
Adding dependence to junit-dep instead of junit - this is to help with projects that separately add a dependency to hamcrest-core and hamcrest-library, since junit(without dep) has some hamcrest classes built in, this tends to conflict in some cases.
