### PR TITLE
Fix silent failure when an exception is thrown from a @BeforeClass method

### DIFF
--- a/src/main/java/com/novocode/junit/RunSettings.java
+++ b/src/main/java/com/novocode/junit/RunSettings.java
@@ -62,17 +62,18 @@ class RunSettings {
       b.append(c(cn.substring(pos2+1), c1));
     }
 
-    b.append('.');
-
     String m = desc.getMethodName();
-    int mpos1 = m.lastIndexOf('[');
-    int mpos2 = m.lastIndexOf(']');
-    if(mpos1 == -1 || mpos2 < mpos1) b.append(c(decodeName(m), c2));
-    else {
-      b.append(c(decodeName(m.substring(0, mpos1)), c2));
-      b.append('[');
-      b.append(c(m.substring(mpos1+1, mpos2), c3));
-      b.append(']');
+    if(m != null) {
+      b.append('.');
+      int mpos1 = m.lastIndexOf('[');
+      int mpos2 = m.lastIndexOf(']');
+      if(mpos1 == -1 || mpos2 < mpos1) b.append(c(decodeName(m), c2));
+      else {
+        b.append(c(decodeName(m.substring(0, mpos1)), c2));
+        b.append('[');
+        b.append(c(m.substring(mpos1+1, mpos2), c3));
+        b.append(']');
+      }
     }
 
     return b.toString();


### PR DESCRIPTION
In this case, `desc.getMethodName()` returns `null`, which causes an exception when the next line tries to call a method on it.  The system then swallows the exception and it is not registered in the results.
