### PR TITLE
Override equals method of RunWithFingerprint

### DIFF
--- a/src/main/java/com/novocode/junit/AbstractAnnotatedFingerprint.java
+++ b/src/main/java/com/novocode/junit/AbstractAnnotatedFingerprint.java
@@ -1,0 +1,12 @@
+package com.novocode.junit;
+
+import org.scalatools.testing.AnnotatedFingerprint;
+
+public abstract class AbstractAnnotatedFingerprint implements AnnotatedFingerprint {
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AnnotatedFingerprint)) return false;
+    AnnotatedFingerprint f = (AnnotatedFingerprint) obj;
+    return annotationName().equals(f.annotationName()) && isModule() == f.isModule();
+  }
+}

--- a/src/main/java/com/novocode/junit/JUnitFingerprint.java
+++ b/src/main/java/com/novocode/junit/JUnitFingerprint.java
@@ -1,19 +1,9 @@
 package com.novocode.junit;
 
-import org.scalatools.testing.AnnotatedFingerprint;
-
-
-public class JUnitFingerprint implements AnnotatedFingerprint {
+public class JUnitFingerprint extends AbstractAnnotatedFingerprint {
   @Override
   public String annotationName() { return "org.junit.Test"; }
 
   @Override
   public boolean isModule() { return false; }
-
-  @Override
-  public boolean equals(Object obj) {
-    if(!(obj instanceof AnnotatedFingerprint)) return false;
-    AnnotatedFingerprint f = (AnnotatedFingerprint)obj;
-    return annotationName().equals(f.annotationName()) && isModule() == f.isModule();
-  }
 }

--- a/src/main/java/com/novocode/junit/RunWithFingerprint.java
+++ b/src/main/java/com/novocode/junit/RunWithFingerprint.java
@@ -1,10 +1,6 @@
 package com.novocode.junit;
 
-import org.scalatools.testing.AnnotatedFingerprint;
-
-
-public class RunWithFingerprint implements AnnotatedFingerprint
-{
+public class RunWithFingerprint extends AbstractAnnotatedFingerprint {
   @Override
   public String annotationName() { return "org.junit.runner.RunWith"; }
 


### PR DESCRIPTION
I encountered an issue when both RunWith and JUnit fingerprints were picked.
When I run jacoco:cover, sbt doesn't pick RunWith fingerprint because strangely two different RunWith fingerprints exist in sbt and are compared when picking one from RunWith and JUnit fingerprints.
RunWith fingerprint didn't override equals method so equals returned false and JUnit fingerprint was picked in this case.
So I overrode the equals method of both and created a common abstract class.
