### PR TITLE
Initialize Slf4j to avoid race condition in its initialization phase.

### DIFF
--- a/src/main/java/com/novocode/junit/JUnitFramework.java
+++ b/src/main/java/com/novocode/junit/JUnitFramework.java
@@ -14,6 +14,10 @@ public final class JUnitFramework implements Framework
     new RunWithFingerprint()
   };
 
+  public JUnitFramework() {
+    Slf4jInitialization.initialize();
+  }
+
   @Override
   public String name() { return "JUnit"; }
 

--- a/src/main/java/com/novocode/junit/Slf4jInitialization.java
+++ b/src/main/java/com/novocode/junit/Slf4jInitialization.java
@@ -1,0 +1,14 @@
+package com.novocode.junit;
+
+public class Slf4jInitialization {
+  public static void initialize() {
+    ClassLoader cl = Slf4jInitialization.class.getClassLoader();
+    try {
+      cl.loadClass("org.slf4j.LoggerFactory")
+        .getMethod("getLogger", String.class)
+        .invoke(null, "ROOT");
+    } catch (Exception e) {
+      // swallow - we might not have slf4j on the classpath
+    }
+  }
+}


### PR DESCRIPTION
See http://stackoverflow.com/questions/7898273/how-to-get-logging-working-in-scala-unit-tests-with-testng-slf4s-and-logback
