### PR TITLE
Changing order of fingerprints to allow tests with @RunWith to execute

### DIFF
--- a/src/main/java/com/novocode/junit/JUnitFramework.java
+++ b/src/main/java/com/novocode/junit/JUnitFramework.java
@@ -9,9 +9,9 @@ import org.scalatools.testing.Runner;
 public final class JUnitFramework implements Framework
 {
   private static final Fingerprint[] FINGERPRINTS = new Fingerprint[] {
+    new RunWithFingerprint(),
     new JUnitFingerprint(),
-    new JUnit3Fingerprint(),
-    new RunWithFingerprint()
+    new JUnit3Fingerprint()
   };
 
   @Override


### PR DESCRIPTION
I found that when tests that were annotated with @RunWith(SpringJUnit4ClassRunner.class) did not get properly executed when using junit-interface (sbt 0.13). After some digging, it appeared that it was because these test definitions were being assigned the JunitFingerprint, when they should have been assigned the RunWithFingerprint. My guess was that the first matching fingerprint for each test definition was used, so it made sense that making RunWithFingerprint the first item returned from the framework would cause RunWithFingerprint to be assigned to test definitions having the @RunWith annotation - after switching to the forked version with the new ordering, my tests now execute using the Junit Runner as expected.
