### PR TITLE
Clarify --tests usage

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -66,8 +66,9 @@ The following options are supported for JUnit tests:
 
   --tests=<REGEXPS>  Run only the tests whose names match one of the specified
       regular expressions (in a comma-separated list). Non-matched tests are
-      ignored. Only individual test cases are matched, not test classes. Use
-      sbt's "test-only" command instead to match test classes.
+      ignored. Only individual test case names are matched, not test classes.
+      Example: For test MyClassTest.testBasic() only "testBasic" is matched.
+      Use sbt's "test-only" command instead to match test classes.
 
   -Dkey=value Temporarily set a system property for the duration of the test
       run. The property is restored to its previous value after the test has


### PR DESCRIPTION
After reading the existing --tests documentation it still wasn't clear to my co-worker or me that the flag would only match the names of the classes, but not the path or class name.  This should make it clear.
