### PR TITLE
Add scripted test for https://github.com/sbt/junit-interface/issues/14

### DIFF
--- a/src/sbt-test/simple/tests-run-once/build.sbt
+++ b/src/sbt-test/simple/tests-run-once/build.sbt
@@ -1,0 +1,7 @@
+name := """tests-run-once"""
+
+scalaVersion := "2.10.2"
+
+libraryDependencies += "com.novocode" % "junit-interface" % sys.props("project.version") % "test"
+
+fork in Test := true

--- a/src/sbt-test/simple/tests-run-once/src/test/java/MyTest.java
+++ b/src/sbt-test/simple/tests-run-once/src/test/java/MyTest.java
@@ -1,0 +1,18 @@
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+
+public class MyTest extends SuperclassTests  {
+  private static int testRuns = 0;
+
+  @Test
+  public void simpleCheck() {
+    System.out.println("hello" + testRuns);
+    testRuns++;
+    Assert.assertEquals(1, testRuns);
+  }
+  
+}

--- a/src/sbt-test/simple/tests-run-once/src/test/java/SuperclassTests.java
+++ b/src/sbt-test/simple/tests-run-once/src/test/java/SuperclassTests.java
@@ -1,0 +1,9 @@
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public abstract class SuperclassTests {
+}

--- a/src/sbt-test/simple/tests-run-once/test
+++ b/src/sbt-test/simple/tests-run-once/test
@@ -1,0 +1,2 @@
+# verify that tests run once
+> test


### PR DESCRIPTION
The test included in this pull request reproduces the behaviour seen in https://github.com/sbt/junit-interface/issues/14.

I've taken a look at the patch submitted by szeiger and I've found the cause of the issue - it ignores suite runners based on class names rather than examining the type of the suite runner. If you use @RunWith with a subclass of Suite, your tests will still be run twice. To reproduce the problem, I simply subclassed Suite and annotated MyTest to @RunWith the new runner.
