### PR TITLE
Should work for cucumber scenario outlines

### DIFF
--- a/src/main/java/com/novocode/junit/EventDispatcher.java
+++ b/src/main/java/com/novocode/junit/EventDispatcher.java
@@ -61,7 +61,7 @@ final class EventDispatcher extends RunListener
   public void testAssumptionFailure(final Failure failure)
   {
     uncapture(true);
-    postIfFirst(new ErrorEvent(failure, Status.Skipped) {
+    post(new ErrorEvent(failure, Status.Skipped) {
       void logTo(RichLogger logger) {
         logger.warn("Test assumption in test "+ansiName+" failed: "+ansiMsg + durationSuffix());
       }
@@ -72,7 +72,7 @@ final class EventDispatcher extends RunListener
   public void testFailure(final Failure failure)
   {
     uncapture(true);
-    postIfFirst(new ErrorEvent(failure, Status.Failure) {
+    post(new ErrorEvent(failure, Status.Failure) {
       void logTo(RichLogger logger) {
         logger.error("Test "+ansiName+" failed: "+ansiMsg + durationSuffix(), error);
       }
@@ -83,7 +83,7 @@ final class EventDispatcher extends RunListener
   public void testFinished(Description desc)
   {
     uncapture(false);
-    postIfFirst(new InfoEvent(desc, Status.Success) {
+    post(new InfoEvent(desc, Status.Success) {
       void logTo(RichLogger logger) {
         logger.debug("Test "+ansiName+" finished" + durationSuffix());
       }
@@ -94,7 +94,7 @@ final class EventDispatcher extends RunListener
   @Override
   public void testIgnored(Description desc)
   {
-    postIfFirst(new InfoEvent(desc, Status.Skipped) {
+    post(new InfoEvent(desc, Status.Skipped) {
       void logTo(RichLogger logger) {
         logger.info("Test "+ansiName+" ignored");
       }
@@ -146,12 +146,6 @@ final class EventDispatcher extends RunListener
         logger.error("Execution of test "+ansiName+" failed: "+ansiMsg, error);
       }
     });
-  }
-
-  private void postIfFirst(AbstractEvent e)
-  {
-    e.logTo(logger);
-    if(reported.add(e.fullyQualifiedName())) handler.handle(e);
   }
 
   void post(AbstractEvent e)

--- a/src/sbt-test/cucumber/scenario_outlines/build.sbt
+++ b/src/sbt-test/cucumber/scenario_outlines/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq (
         "io.cucumber" %% "cucumber-scala" % "2.0.0" % "test",
         "io.cucumber" % "cucumber-jvm" % "2.0.0" % "test",
         "io.cucumber" % "cucumber-junit" % "2.0.0" % "test",
-        "com.novocode" % "junit-interface" % "0.11" % "test")
+        "com.novocode" % "junit-interface" % sys.props("project.version") % "test")
 
 def before() : Unit = { println("beforeAll") }
 def after() : Unit = { println("afterAll") }

--- a/src/sbt-test/cucumber/scenario_outlines/build.sbt
+++ b/src/sbt-test/cucumber/scenario_outlines/build.sbt
@@ -1,0 +1,19 @@
+name := "cucumber-test"
+
+organization := "com.waioeka.sbt"
+
+version := "0.0.4"
+
+scalaVersion := "2.12.2"
+
+libraryDependencies ++= Seq (
+        "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+        "io.cucumber" % "cucumber-core" % "2.0.0" % "test",
+        "io.cucumber" %% "cucumber-scala" % "2.0.0" % "test",
+        "io.cucumber" % "cucumber-jvm" % "2.0.0" % "test",
+        "io.cucumber" % "cucumber-junit" % "2.0.0" % "test",
+        "com.novocode" % "junit-interface" % "0.11" % "test")
+
+def before() : Unit = { println("beforeAll") }
+def after() : Unit = { println("afterAll") }
+

--- a/src/sbt-test/cucumber/scenario_outlines/src/test/resources/features/Multiplication.feature
+++ b/src/sbt-test/cucumber/scenario_outlines/src/test/resources/features/Multiplication.feature
@@ -1,0 +1,16 @@
+@my-tag
+Feature: Multiplication
+  In order to avoid making mistakes
+  As a dummy
+  I want to multiply numbers
+
+  Scenario Outline: Multiply two variables
+    Given a variable x with value <x>
+    And a variable y with value <y>
+    When I multiply x * y
+    Then I get <z>
+    Examples:
+    | x | y | z |
+    | 1 | 1 | 1 |
+    | 2 | 3 | 1 |
+

--- a/src/sbt-test/cucumber/scenario_outlines/src/test/scala/com/waioeka/sbt/MultiplicationSteps.scala
+++ b/src/sbt-test/cucumber/scenario_outlines/src/test/scala/com/waioeka/sbt/MultiplicationSteps.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015, Michael Lewis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.waioeka.sbt
+
+import cucumber.api.scala.{ScalaDsl, EN}
+import org.scalatest.Matchers
+
+
+/**
+  * AddAndMultiplySteps
+  *
+  */
+class MultiplicationSteps extends ScalaDsl with EN with Matchers {
+  var x : Int = 0
+  var y : Int = 0
+  var z : Int = 0
+
+
+  Given("""^a variable x with value (\d+)$""") { (arg0: Int) =>
+    x = arg0
+  }
+
+  Given("""^a variable y with value (\d+)$""") { (arg0: Int) =>
+    y = arg0
+  }
+
+  When("""^I multiply x \* y$""") { () =>
+    z = x * y
+  }
+
+ Then("""^I get (\d+)$""") { (arg0: Int) =>
+   z should be (arg0)
+ }
+}

--- a/src/sbt-test/cucumber/scenario_outlines/src/test/scala/cucumber/CucumberApplicationSpec.scala
+++ b/src/sbt-test/cucumber/scenario_outlines/src/test/scala/cucumber/CucumberApplicationSpec.scala
@@ -1,0 +1,14 @@
+package cucumber
+
+import cucumber.api.CucumberOptions
+import cucumber.api.junit.Cucumber
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(
+  features = Array("classpath:features"),
+  glue = Array("com.waioeka.sbt"),
+  strict = true,
+)
+class CucumberApplicationSpec
+

--- a/src/sbt-test/cucumber/scenario_outlines/test
+++ b/src/sbt-test/cucumber/scenario_outlines/test
@@ -1,0 +1,2 @@
+# run the cucumber tests and see them fail
+-> test


### PR DESCRIPTION
# Problem

Cucumber tests with [Data Tables](https://en.wikipedia.org/wiki/Cucumber_(software)#Scenarios) will pass with failing examples as long as the first example passes.

This happens because all the examples in have the same fully qualified name that comes from the scenario outline description.

# The changes

This Pr simply allows for tests with equal names to pass through from the JUnit RunNotifier to the SBT EventHandler without repeats being filtered out.

The first commit in this test is a passing test that should have failed and the second commit is the fix.