### PR TITLE
Rename scripted var to plugin.version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ pomExtra :=
 enablePlugins(SbtPlugin)
 scriptedBufferLog := false
 scriptedLaunchOpts ++= Seq(
-  s"-Dproject.version=${version.value}",
+  s"-Dplugin.version=${version.value}",
   "-Xmx256m"
 )
 

--- a/src/sbt-test/simple/can-run-single-test/build.sbt
+++ b/src/sbt-test/simple/can-run-single-test/build.sbt
@@ -1,8 +1,8 @@
 name := "test-project"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.7"
 
-libraryDependencies += "com.novocode" % "junit-interface" % sys.props("project.version") % "test"
+libraryDependencies += "com.novocode" % "junit-interface" % sys.props("plugin.version") % "test"
 
 
 val checkTestDefinitions = taskKey[Unit]("Tests that the test is discovered properly")

--- a/src/sbt-test/simple/categories/build.sbt
+++ b/src/sbt-test/simple/categories/build.sbt
@@ -1,8 +1,8 @@
 name := "test-project"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.7"
 
-libraryDependencies += "com.novocode" % "junit-interface" % sys.props("project.version") % "test"
+libraryDependencies += "com.novocode" % "junit-interface" % sys.props("plugin.version") % "test"
 
 InputKey[Unit]("tests-executed") := {
   val expected = Def.spaceDelimited("<test-classes>").parsed

--- a/src/sbt-test/simple/test-listener/build.sbt
+++ b/src/sbt-test/simple/test-listener/build.sbt
@@ -1,8 +1,8 @@
 name := "test-project"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.7"
 
-libraryDependencies += "com.novocode" % "junit-interface" % sys.props("project.version") % "test"
+libraryDependencies += "com.novocode" % "junit-interface" % sys.props("plugin.version") % "test"
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-n", "--run-listener=test.JUnitListener")
 

--- a/src/sbt-test/simple/tests-run-once/build.sbt
+++ b/src/sbt-test/simple/tests-run-once/build.sbt
@@ -1,8 +1,8 @@
 name := """tests-run-once"""
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.7"
 
-libraryDependencies += "com.novocode" % "junit-interface" % sys.props("project.version") % "test"
+libraryDependencies += "com.novocode" % "junit-interface" % sys.props("plugin.version") % "test"
 
 fork in Test := true
 


### PR DESCRIPTION
Follows convention in <https://www.scala-sbt.org/release/docs/Testing-sbt-plugins.html>