### PR TITLE
JUnit 4.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val `junit-interface` = (project in file("."))
     sbtPlugin := false
 
     libraryDependencies ++= Seq(
-      "junit" % "junit" % "4.13",
+      "junit" % "junit" % "4.13.1",
       "org.scala-sbt" % "test-interface" % "1.0",
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val `junit-interface` = (project in file("."))
     sbtPlugin := false
 
     libraryDependencies ++= Seq(
-      "junit" % "junit" % "4.12",
+      "junit" % "junit" % "4.13",
       "org.scala-sbt" % "test-interface" % "1.0",
     )
 


### PR DESCRIPTION
https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md

### Security fix: TemporaryFolder now limits access to temporary folders on Java 1.7 or later

A local information disclosure vulnerability in `TemporaryFolder` has been fixed. See the published [security advisory](https://github.com/junit-team/junit4/security/advisories/GHSA-269g-pwp5-87pp) for details.