### PR TITLE
Take into account `TaskDef`s with `TestSelector`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ target
 /\.manager/
 /\.idea/
 /\.idea_modules/
+.metals/
+.bloop/
+.bsp/
+.vscode/

--- a/src/main/java/com/novocode/junit/RunSettings.java
+++ b/src/main/java/com/novocode/junit/RunSettings.java
@@ -50,6 +50,15 @@ class RunSettings {
     this.testFilter = testFilter;
   }
 
+  public RunSettings withTestFilter(String newTestFilter) {
+    String ignoreRunners = String.join(",", this.ignoreRunners);
+    return new RunSettings(
+        this.color, this.decodeScalaNames, this.quiet, this.verbosity, this.summary, this.logAssert,
+        ignoreRunners, this.logExceptionClass, this.sysprops, this.globPatterns, this.includeCategories,
+        this.excludeCategories, newTestFilter
+    );
+  }
+
   String decodeName(String name) {
     return decodeScalaNames ? decodeScalaName(name) : name;
   }
@@ -108,7 +117,7 @@ class RunSettings {
 
   private String buildColoredName(Description desc, String c1, String c2, String c3) {
     StringBuilder b = new StringBuilder();
-    
+
     String cn = decodeName(desc.getClassName());
     int pos1 = cn.indexOf('$');
     int pos2 = pos1 == -1 ? cn.lastIndexOf('.') : cn.lastIndexOf('.', pos1);

--- a/src/sbt-test/simple/check-test-selector/build.sbt
+++ b/src/sbt-test/simple/check-test-selector/build.sbt
@@ -1,0 +1,6 @@
+name := "test-project"
+
+scalaVersion := "2.13.7"
+
+libraryDependencies += "com.github.sbt" % "junit-interface" % sys.props("plugin.version") % "test"
+libraryDependencies += "org.scala-sbt" % "test-agent" % "1.5.5" % Test

--- a/src/sbt-test/simple/check-test-selector/project/build.properties
+++ b/src/sbt-test/simple/check-test-selector/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/src/sbt-test/simple/check-test-selector/src/test/scala/CheckTestSelector.scala
+++ b/src/sbt-test/simple/check-test-selector/src/test/scala/CheckTestSelector.scala
@@ -1,0 +1,102 @@
+import com.novocode.junit.JUnitFramework
+import com.novocode.junit.JUnitFingerprint
+
+import org.junit.Test
+import org.junit.Assert._
+
+import sbt.testing._
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Check if TestSelector's are correctly handled by JUnitRunner.
+  * Execute prepared TaskDef's using manually created instances of sbt.testing.{Framework and Runner}.
+  */
+class CheckTestSelector {
+  val framework = new JUnitFramework();
+  val runner = framework.runner(
+    Array.empty[String],
+    Array.empty[String],
+    this.getClass().getClassLoader()
+  );
+
+  private def getEventHandler(): (ArrayBuffer[String], EventHandler) = {
+    val executedItems = new scala.collection.mutable.ArrayBuffer[String]
+    val eventHandler = new EventHandler {
+      override def handle(event: Event) =
+        if (event.status() == Status.Success) {
+          executedItems.addOne(event.fullyQualifiedName())
+        }
+    }
+    (executedItems, eventHandler)
+  }
+
+  private def getTaskDefs(selectors: Array[Selector]): Array[TaskDef] = {
+    Array(
+      new TaskDef("a.b.MyTestSuite", new JUnitFingerprint(), false, selectors)
+    )
+  }
+
+  @Test
+  def runAllViaSuiteSelector() {
+    val selectors = Array[Selector](
+      new SuiteSelector
+    )
+    val taskDefs = Array(
+      new TaskDef("a.b.MyTestSuite", new JUnitFingerprint(), false, selectors)
+    )
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertArrayEquals(
+      Array[Object]("a.b.MyTestSuite.testBar", "a.b.MyTestSuite.testFoo"),
+      executedItems.toArray[Object]
+    )
+  }
+
+  @Test
+  def runAllViaTestSelectors() {
+    val selectors = Array[Selector](
+      new TestSelector("testFoo"),
+      new TestSelector("testBar")
+    )
+    val taskDefs = getTaskDefs(selectors)
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertArrayEquals(
+      Array[Object]("a.b.MyTestSuite.testBar", "a.b.MyTestSuite.testFoo"),
+      executedItems.toArray[Object]
+    )
+  }
+
+  @Test
+  def runOnlyOne() {
+    val selectors = Array[Selector](
+      new TestSelector("testFoo")
+    )
+    val taskDefs = getTaskDefs(selectors)
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertArrayEquals(
+      Array[Object]("a.b.MyTestSuite.testFoo"),
+      executedItems.toArray[Object]
+    )
+
+  }
+}

--- a/src/sbt-test/simple/check-test-selector/src/test/scala/a/b/MyTestSuite.scala
+++ b/src/sbt-test/simple/check-test-selector/src/test/scala/a/b/MyTestSuite.scala
@@ -1,0 +1,17 @@
+package a.b
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class MyTestSuite {
+
+  @Test
+  def testFoo(): Unit = {
+    assertEquals("Test should pass", true, true)
+  }
+
+  @Test
+  def testBar(): Unit = {
+    assertEquals("Test should pass", true, true)
+  }
+}

--- a/src/sbt-test/simple/check-test-selector/test
+++ b/src/sbt-test/simple/check-test-selector/test
@@ -1,0 +1,2 @@
+# make sure the unit test passes
+> test


### PR DESCRIPTION
As far as I understand, `TestSelector` can be used to create `TaskDef` which should only execute selected tests from the given test class. 

Motivation: from the build server perspective I want to be able to run only a single test from the selected test suite.

I didn't find a better alternative to `RunSettings.testFilter`.